### PR TITLE
Bugfix/Increase Extraction Filesize Limit

### DIFF
--- a/internal/index/extract.go
+++ b/internal/index/extract.go
@@ -16,8 +16,8 @@ import (
 	cindex "veloria/internal/codesearch/index"
 )
 
-// maxDecompressSize is the maximum allowed size for a single decompressed file (100 MB).
-const maxDecompressSize = 100 << 20
+// maxDecompressSize is the maximum allowed size for a single decompressed file (256 MB).
+const maxDecompressSize = 256 << 20
 
 // FileStat holds information about a single file.
 type FileStat struct {


### PR DESCRIPTION
The plugin https://wordpress.org/plugins/instalist/ has a 128mb video file, which was above the filesize limit when extracting archives, causing an error. We want to collect file stats for the worst offenders, and have the storage space, so raising the limit feels right.