### PR TITLE
Feature/Basic Search Moderation

### DIFF
--- a/internal/search/api.go
+++ b/internal/search/api.go
@@ -100,6 +100,9 @@ func CreateSearchV1(reg *service.Registry) http.Handler {
 		if req.Public != nil {
 			private = !*req.Public
 		}
+		if !private && shouldForcePrivate(req.Term) {
+			private = true
+		}
 
 		s := searchmodel.Search{
 			Status:  searchmodel.StatusQueued,

--- a/internal/search/moderation.go
+++ b/internal/search/moderation.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"regexp"
+	"strings"
+)
+
+// urlPattern matches common URL patterns in search terms.
+var urlPattern = regexp.MustCompile(`(?i)(https?://|www\.|[a-z0-9-]+\.(com|net|org|io|co|info|biz|xyz|ru|cn|tk|ml|ga|cf|gq|top|work|click|link|site|online|store|shop|dev|app)\b)`)
+
+// blockedWords is a fixed list of slurs, insults, and offensive terms that
+// should force a search to be private so they don't appear on public listings.
+// This is intentionally a curated list of unambiguous slurs — words that have
+// no legitimate use in a code-search context.
+// If this is not enough use LDNOOBW (List of Dirty, Naughty, Obscene, and Otherwise Bad Words).
+var blockedWords = []string{
+	"nigger",
+	"nigga",
+	"faggot",
+	"fag",
+	"retard",
+	"retarded",
+	"tranny",
+	"kike",
+	"spic",
+	"wetback",
+	"chink",
+	"gook",
+	"coon",
+	"darkie",
+	"beaner",
+	"towelhead",
+	"raghead",
+	"whore",
+	"slut",
+	"cunt",
+	"porn",
+	"pornhub",
+	"xvideos",
+	"xhamster",
+	"hentai",
+	"onlyfans",
+	"casino",
+	"viagra",
+	"cialis",
+	"buy cheap",
+	"free money",
+}
+
+// shouldForcePrivate returns true if the search term contains a URL or
+// blocked word, meaning it should not appear in public search listings.
+func shouldForcePrivate(term string) bool {
+	if urlPattern.MatchString(term) {
+		return true
+	}
+
+	lower := strings.ToLower(term)
+	for _, word := range blockedWords {
+		if strings.Contains(lower, word) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/search/moderation_test.go
+++ b/internal/search/moderation_test.go
@@ -1,0 +1,55 @@
+package search
+
+import "testing"
+
+func TestShouldForcePrivate(t *testing.T) {
+	tests := []struct {
+		name string
+		term string
+		want bool
+	}{
+		// Normal search terms — should remain public.
+		{"normal term", "add_action", false},
+		{"normal with spaces", "wp_query meta_key", false},
+		{"regex pattern", `\.php$`, false},
+		{"code pattern", "eval(base64_decode", false},
+
+		// URLs — should be forced private.
+		{"http url", "https://example.com/scam", true},
+		{"http no s", "http://spam.net", true},
+		{"www prefix", "www.buycheapstuff.com", true},
+		{"bare domain .com", "visit example.com today", true},
+		{"bare domain .net", "check spam.net now", true},
+		{"bare domain .org", "go to evil.org", true},
+		{"bare domain .io", "my-site.io", true},
+		{"bare domain .xyz", "cheap.xyz", true},
+		{"bare domain .ru", "malware.ru", true},
+		{"bare domain .shop", "deals.shop", true},
+
+		// Blocked words — should be forced private.
+		{"slur", "nigger", true},
+		{"slur mixed case", "NIGGER", true},
+		{"slur in phrase", "some nigga stuff", true},
+		{"offensive word", "faggot", true},
+		{"spam keyword", "buy cheap pills", true},
+		{"porn site", "pornhub", true},
+		{"casino spam", "casino bonus free", true},
+		{"viagra spam", "viagra online", true},
+
+		// Already private — function still returns true (caller handles dedup).
+		{"url still flagged", "https://scam.com", true},
+
+		// Edge cases.
+		{"empty string", "", false},
+		{"domain-like but not TLD", "example.notarealtld", false},
+		{"partial word ok", "document", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldForcePrivate(tt.term); got != tt.want {
+				t.Errorf("shouldForcePrivate(%q) = %v, want %v", tt.term, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/search/web.go
+++ b/internal/search/web.go
@@ -61,6 +61,9 @@ func ViewPage(d *web.Deps) http.HandlerFunc {
 			PageData: pd,
 			Search:   s,
 		}
+		if s.Private && shouldForcePrivate(s.Term) {
+			data.ModerationNotice = "This search has been automatically set to private because the search term contains a URL or inappropriate language."
+		}
 		if s.CompletedAt != nil {
 			data.DurationMs = s.CompletedAt.Sub(s.CreatedAt).Milliseconds()
 		}
@@ -305,6 +308,9 @@ func SubmitSearch(d *web.Deps) http.HandlerFunc {
 		}
 
 		private := visibility == "private"
+		if !private && shouldForcePrivate(term) {
+			private = true
+		}
 
 		currentUser := auth.UserFromContext(r.Context())
 

--- a/internal/ui/page/search_view.templ
+++ b/internal/ui/page/search_view.templ
@@ -11,6 +11,9 @@ import (
 
 templ SearchView(data ui.SearchViewData) {
 	@layout.Base(data.PageData) {
+		if data.ModerationNotice != "" {
+			@shared.InfoAlert(data.ModerationNotice)
+		}
 		<!-- Heading -->
 		<div class="mb-6 pt-8 lg:pt-10">
 			<p class="text-xs text-text-bright uppercase tracking-widest mb-1.5">Search Result</p>

--- a/internal/ui/shared/info_alert.templ
+++ b/internal/ui/shared/info_alert.templ
@@ -1,0 +1,14 @@
+package shared
+
+templ InfoAlert(message string) {
+	<div class="glass-inner mb-6 p-4 border-amber-200/30 bg-amber-50/5 text-amber-400">
+		<div class="flex items-center gap-2">
+			<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<circle cx="12" cy="12" r="10"></circle>
+				<line x1="12" y1="8" x2="12" y2="12"></line>
+				<line x1="12" y1="16" x2="12.01" y2="16"></line>
+			</svg>
+			<span>{ message }</span>
+		</div>
+	</div>
+}

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -79,6 +79,7 @@ type SearchViewData struct {
 	ProgressSearched int
 	ProgressTotal    int
 	Error            string
+	ModerationNotice string
 }
 
 // SearchExtensionsData contains data for the search extensions HTMX partial.


### PR DESCRIPTION
If a malicious user adds an ad/scam URL to the search term, or racist/rude words, they appear publicly in the search list. This implements a basic attempt to automatically set searches private when these scenarios are detected.