### PR TITLE
Bugfix/Search Match Cap Notice

### DIFF
--- a/internal/search/web.go
+++ b/internal/search/web.go
@@ -80,6 +80,7 @@ func ViewPage(d *web.Deps) http.HandlerFunc {
 		if s.Status == searchmodel.StatusCompleted {
 			if s.TotalMatches != nil {
 				data.TotalMatches = *s.TotalMatches
+				data.MatchCapReached = *s.TotalMatches >= 100_000
 			}
 			if s.TotalExtensions != nil {
 				data.TotalExtensions = *s.TotalExtensions

--- a/internal/ui/page/search_view.templ
+++ b/internal/ui/page/search_view.templ
@@ -106,6 +106,9 @@ templ searchContentInner(data ui.SearchViewData) {
 		@shared.ErrorAlert(data.Error)
 	}
 	if data.TotalExtensions > 0 {
+		if data.MatchCapReached {
+			@shared.InfoAlert("This search hit the maximum cap of 100,000 matches and was terminated before finishing. Some extensions may not have been searched.")
+		}
 		<!-- Results Summary -->
 		<div class="glass-inner p-5 mb-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
 			<p class="text-text-body text-base">

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -80,6 +80,7 @@ type SearchViewData struct {
 	ProgressTotal    int
 	Error            string
 	ModerationNotice string
+	MatchCapReached  bool
 }
 
 // SearchExtensionsData contains data for the search extensions HTMX partial.


### PR DESCRIPTION
Adds a notice to searches if they were terminated after hitting the match cap of 100,000.