### PR TITLE
Bugfix/Improve Control Over Logging

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -342,7 +342,7 @@ func (a *App) initDB() error {
 	c := a.Config
 
 	var logLevel gormlogger.LogLevel
-	if c.AppDebug {
+	if c.DBDebug {
 		logLevel = gormlogger.Info
 	} else {
 		logLevel = gormlogger.Error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,8 +80,11 @@ type Config struct {
 	// MCP: enable the remote MCP server endpoint
 	MCPEnabled bool `env:"MCP_ENABLED" envDefault:"true"`
 
-	// Debug mode: controls informational (non-error/warning) log output
+	// Debug mode: enables extra informational log output (errors/warnings always logged)
 	AppDebug bool `env:"APP_DEBUG" envDefault:"false"`
+
+	// DB debug mode: logs all SQL queries (default: only errors)
+	DBDebug bool `env:"DB_DEBUG" envDefault:"false"`
 
 	// Reconnect interval: how often to retry failed service connections
 	ReconnectInterval time.Duration `env:"RECONNECT_INTERVAL" envDefault:"30s"`

--- a/internal/log/zap.go
+++ b/internal/log/zap.go
@@ -13,16 +13,17 @@ import (
 // Config holds logging configuration.
 type Config struct {
 	ServiceName string
-	Development bool
+	Development bool // Controls output format (console vs JSON)
+	Debug       bool // Enables debug/info level output (errors/warnings always logged)
 }
 
 // NewZapLogger creates a Zap logger that bridges to OpenTelemetry.
-// In development mode, it uses a console encoder with colored output at Debug level.
-// In production mode, it uses JSON encoding at Warn level.
-// Both modes tee output to both local output and OTel.
+// Development controls the output format: console with color (dev) or JSON (prod).
+// Debug controls the minimum log level: Debug (on) or Warn (off).
+// Errors and warnings are always logged regardless of Debug setting.
 func NewZapLogger(cfg Config, otelProvider *sdklog.LoggerProvider) *zap.Logger {
 	level := zapcore.WarnLevel
-	if cfg.Development {
+	if cfg.Development || cfg.Debug {
 		level = zapcore.DebugLevel
 	}
 

--- a/internal/telemetry/logging.go
+++ b/internal/telemetry/logging.go
@@ -29,7 +29,8 @@ func newLoggerProvider(ctx context.Context, cfg *config.Config, res *resource.Re
 		// No OTel log export — Zap works standalone with local output only.
 		zapLogger := velorialog.NewZapLogger(velorialog.Config{
 			ServiceName: cfg.Name,
-			Development: isDev || cfg.AppDebug,
+			Development: isDev,
+			Debug:       cfg.AppDebug,
 		}, nil)
 
 		return &LoggingResult{Logger: zapLogger}, nil
@@ -61,7 +62,8 @@ func newLoggerProvider(ctx context.Context, cfg *config.Config, res *resource.Re
 
 	zapLogger := velorialog.NewZapLogger(velorialog.Config{
 		ServiceName: cfg.Name,
-		Development: isDev || cfg.AppDebug,
+		Development: isDev,
+		Debug:       cfg.AppDebug,
 	}, provider)
 
 	return &LoggingResult{


### PR DESCRIPTION
Introduces `DB_DEBUG` to control Gorm logging, and automatically switches logging output based on `ENV`.