### PR TITLE
Bugfix/Strip the MCP Connections From Tracing

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,12 @@ type Server struct {
 // Otherwise: plain HTTP on the configured port.
 func New(handler http.Handler, c *config.Config, l *zap.Logger) (*Server, error) {
 	// Wrap the root handler with OTel HTTP instrumentation.
-	instrumentedHandler := otelhttp.NewHandler(handler, "veloria")
+	// Exclude long-lived streaming endpoints that skew duration metrics.
+	instrumentedHandler := otelhttp.NewHandler(handler, "veloria",
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			return r.URL.Path != "/mcp"
+		}),
+	)
 
 	s := &Server{
 		logger: l,


### PR DESCRIPTION
The MCP connections are long lived (2mins) and these traces ruin the overall request duration data, striping them for now until I find a better solution.