### PR TITLE
Bugfix/Search Match Extension Count

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.uber.org/zap"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
+	"go.uber.org/zap"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -571,7 +571,7 @@ type extensionRow struct {
 // convertManagerResponse converts a manager.SearchResponse to our MCP SearchResponse.
 func convertManagerResponse(results *manager.SearchResponse) *SearchResponse {
 	resp := &SearchResponse{
-		TotalExtensions: results.Total,
+		TotalExtensions: len(results.Results),
 		Extensions:      make([]ExtensionResult, 0, len(results.Results)),
 	}
 

--- a/internal/search/api.go
+++ b/internal/search/api.go
@@ -169,7 +169,7 @@ func runAPISearchAsync(db *gorm.DB, m *manager.Manager, s3 storage.ResultStorage
 
 	now := time.Now()
 	totalMatches := web.CountTotalMatches(results)
-	persistSearchResults(db, s3, searchID, results, now, totalMatches, results.Total)
+	persistSearchResults(db, s3, searchID, results, now, totalMatches, len(results.Results))
 }
 
 // persistSearchResults uploads search results to S3 and updates the DB record.

--- a/internal/search/web.go
+++ b/internal/search/web.go
@@ -396,7 +396,7 @@ func runSearchAsync(d *web.Deps, searchID uuid.UUID, repo, term, fileMatch, excl
 		"results_size":     size,
 		"completed_at":     now,
 		"total_matches":    totalMatches,
-		"total_extensions": results.Total,
+		"total_extensions": len(results.Results),
 	})
 }
 


### PR DESCRIPTION
Sets the search match extension count to be the number of extensions containing matches, instead of the total number of extensions.