### PR TITLE
Bugfix/Handle panic when index corrupt

### DIFF
--- a/internal/index/misc.go
+++ b/internal/index/misc.go
@@ -13,7 +13,9 @@ import (
 
 // Open opens an existing trigram index at the given directory path.
 // The path should point to the directory containing the "trigrams" file.
-func Open(path string) *Index {
+// Returns nil if the trigrams file is missing or the index is corrupt, so
+// callers can delete the bad directory and fall back to a sibling version.
+func Open(path string) (idx *Index) {
 	trigramsPath := filepath.Join(path, "trigrams")
 
 	// Check existence before calling cindex.Open, which log.Fatals on missing files.
@@ -21,15 +23,19 @@ func Open(path string) *Index {
 		return nil
 	}
 
-	ix := cindex.Open(trigramsPath)
-	if ix == nil {
-		log.Printf("failed to open index at: %s", trigramsPath)
-		return nil
-	}
+	// cindex.Open panics with "corrupt index" on malformed data rather than
+	// returning an error. Recover so one bad index cannot crash the service
+	// at startup via the goroutines spawned in manager.NewManager.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("corrupt index at %s: %v", trigramsPath, r)
+			idx = nil
+		}
+	}()
 
 	return &Index{
 		dir: path,
-		idx: ix,
+		idx: cindex.Open(trigramsPath),
 	}
 }
 

--- a/internal/index/misc_test.go
+++ b/internal/index/misc_test.go
@@ -161,6 +161,30 @@ func TestIsTextFile_NonexistentFile(t *testing.T) {
 	}
 }
 
+func TestOpen_MissingTrigrams(t *testing.T) {
+	dir := t.TempDir()
+	if got := Open(dir); got != nil {
+		t.Fatalf("Open(%q) = %v, want nil for missing trigrams file", dir, got)
+	}
+}
+
+func TestOpen_CorruptTrigrams(t *testing.T) {
+	dir := t.TempDir()
+	// A handful of junk bytes cannot satisfy the trailer-magic checks in
+	// cindex.Open, which triggers the "corrupt index" panic path.
+	if err := os.WriteFile(filepath.Join(dir, "trigrams"), []byte("not a real index"), 0o644); err != nil {
+		t.Fatalf("failed to write corrupt trigrams file: %v", err)
+	}
+
+	// The whole point of this test: a corrupt index must not panic the caller.
+	// Before the fix, cindex.Open's panic escaped through Open and crashed the
+	// goroutine in manager.NewManager at service startup.
+	got := Open(dir)
+	if got != nil {
+		t.Fatalf("Open(%q) = %v, want nil for corrupt trigrams file", dir, got)
+	}
+}
+
 func TestTruncateMatchLine(t *testing.T) {
 	fre := regexp.MustCompile(`(?i)target`)
 


### PR DESCRIPTION
Handles the panic thrown when index files are corrupt, allowing the code which deletes them and re-generates to work.